### PR TITLE
Provide convenience Api for creating a ChatMessage

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -57,7 +57,7 @@ impl Bot {
         loop {
             match runner.next_message().await? {
                 Status::Message(Commands::Privmsg(raw_message)) => {
-                    send_incomming_chat_message.send(ChatMessage::new(raw_message))?;
+                    send_incomming_chat_message.send(raw_message.into())?;
                 }
                 Status::Quit | Status::Eof => break,
                 Status::Message(_) => {

--- a/src/chat_message.rs
+++ b/src/chat_message.rs
@@ -1,28 +1,72 @@
 use twitchchat::messages::Privmsg;
 
+#[derive(Debug, Default)]
+pub struct ColorRgb(u8, u8, u8);
+
+pub struct ChatMessageBuilder {
+    message: String,
+    name: String,
+    color: Option<ColorRgb>,
+    display_name: Option<String>,
+    subscriber: bool,
+}
+
+impl ChatMessageBuilder {
+    pub fn new(name: String, message: String) -> Self {
+        ChatMessageBuilder {
+            message,
+            name,
+            color: None,
+            display_name: None,
+            subscriber: false,
+        }
+    }
+
+    pub fn color(mut self, color: ColorRgb) -> Self {
+        self.color = Some(color);
+        self
+    }
+
+    pub fn display_name(mut self, display_name: String) -> Self {
+        self.display_name = Some(display_name);
+        self
+    }
+
+    pub fn subscriber(mut self) -> Self {
+        self.subscriber = true;
+        self
+    }
+
+    pub fn build(self) -> ChatMessage {
+        ChatMessage {
+            message: self.message,
+            name: self.name,
+            color: self.color.unwrap_or_default(),
+            display_name: self.display_name,
+            subscriber: self.subscriber,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct ChatMessage {
     pub message: String,
     pub name: String,
-    pub color_rgb: (u8, u8, u8),
+    pub color: ColorRgb,
     pub display_name: Option<String>,
     pub subscriber: bool,
 }
 
 impl ChatMessage {
-    pub fn new(raw_message: Privmsg) -> ChatMessage {
-        let name = raw_message.name().to_owned();
-        let message = raw_message.data().to_owned();
-        let color_rgb = raw_message
-            .color()
-            .map_or((0, 0, 0), |color| (color.rgb.0, color.rgb.1, color.rgb.2));
-        let display_name = raw_message.display_name().map(|name| name.to_owned());
-        let subscriber = raw_message.is_subscriber();
+    pub fn builder(name: String, message: String) -> ChatMessageBuilder {
+        ChatMessageBuilder::new(name, message)
+    }
 
+    pub fn new(name: String, message: String, color: ColorRgb, display_name: Option<String>, subscriber: bool) -> ChatMessage {
         ChatMessage {
-            name,
             message,
-            color_rgb,
+            name,
+            color,
             display_name,
             subscriber,
         }
@@ -30,7 +74,7 @@ impl ChatMessage {
 
     /// Provided by twitch.tv/lordmzte
     /// uses bit shifting to convert a hex number to rgb
-    fn _hex_to_rgb(hex: &str) -> (u8, u8, u8) {
+    fn _hex_to_rgb(hex: &str) -> ColorRgb {
         //remove # at start
         let hex = hex.trim_start_matches('#');
 
@@ -39,6 +83,26 @@ impl ChatMessage {
 
         //Integer overflow works in our favour here to essentially do the modulo for us.
         //Bit shifts to extract individual colors
-        ((hex_num >> 16) as u8, (hex_num >> 8) as u8, hex_num as u8)
+        ColorRgb((hex_num >> 16) as u8, (hex_num >> 8) as u8, hex_num as u8)
+    }
+}
+
+impl<'a> From<Privmsg<'a>> for ChatMessage {
+    fn from(raw_message: Privmsg) -> Self {
+        let name = raw_message.name().to_owned();
+        let message = raw_message.data().to_owned();
+        let (r, g, b) = raw_message
+            .color()
+            .map_or((0, 0, 0), |color| (color.rgb.0, color.rgb.1, color.rgb.2));
+        let display_name = raw_message.display_name().map(|name| name.to_owned());
+        let subscriber = raw_message.is_subscriber();
+
+        ChatMessage {
+            name,
+            message,
+            color: ColorRgb(r, g, b),
+            display_name,
+            subscriber,
+        }
     }
 }

--- a/src/chat_message.rs
+++ b/src/chat_message.rs
@@ -91,18 +91,19 @@ impl<'a> From<Privmsg<'a>> for ChatMessage {
     fn from(raw_message: Privmsg) -> Self {
         let name = raw_message.name().to_owned();
         let message = raw_message.data().to_owned();
-        let (r, g, b) = raw_message
+        let color = raw_message
             .color()
-            .map_or((0, 0, 0), |color| (color.rgb.0, color.rgb.1, color.rgb.2));
+            .map(|color| ColorRgb(color.rgb.0, color.rgb.1, color.rgb.2))
+            .unwrap_or_default();
         let display_name = raw_message.display_name().map(|name| name.to_owned());
         let subscriber = raw_message.is_subscriber();
 
-        ChatMessage {
+        ChatMessage::new(
             name,
             message,
-            color: ColorRgb(r, g, b),
+            color,
             display_name,
             subscriber,
-        }
+        )
     }
 }


### PR DESCRIPTION
I implemented `From<Privmsg>` for `ChatMessage` and  added a `ChatMessageBuilder` to make it easier to manually create a `ChatMessage`.

This is useful if you want to create `ChatMessages` from another source.
E.g.: If you want to periodically run certain commands.