### PR TITLE
Remove hardcoded env variables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,5 @@ license = "MIT"
 
 [dependencies]
 twitchchat = { version="0.14.4", features=["smol", "async"] }
-dotenv = "0.15.0"
 eyre = "0.6.0"
 smol = "0.3.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,12 +9,13 @@ pub use twitchchat;
 use twitchchat::UserConfig;
 
 pub fn run(
+    name: String,
+    token: String,
+    channels: Vec<String>,
     receive_for_chat: Receiver<String>,
     send_incomming_chat_message: Sender<ChatMessage>,
 ) -> Result<()> {
-    dotenv::dotenv().ok();
-    let user_config = get_user_config()?;
-    let channels = channels_to_join()?;
+    let user_config = get_user_config(name, token)?;
     let bot = Bot;
 
     // run the bot in the executor
@@ -29,23 +30,7 @@ pub fn run(
     })
 }
 
-fn get_env_var(key: &str) -> Result<String> {
-    let my_var = std::env::var(key)?;
-    Ok(my_var)
-}
-
-fn channels_to_join() -> Result<Vec<String>> {
-    let channels = get_env_var("TWITCH_CHANNEL")?
-        .split(',')
-        .map(ToString::to_string)
-        .collect();
-    Ok(channels)
-}
-
-fn get_user_config() -> Result<twitchchat::UserConfig> {
-    let name = get_env_var("TWITCH_NAME")?;
-    let token = get_env_var("TWITCH_TOKEN")?;
-
+fn get_user_config(name: String, token: String) -> Result<twitchchat::UserConfig> {
     let config = UserConfig::builder()
         .name(name)
         .token(token)


### PR DESCRIPTION
I removed the hardcoded environment variables and replaced them with parameters on the run function. This allows running multiple bots at the same time.